### PR TITLE
Fix demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Paths
 
-Edit SVG paths in the browser http://jxnblk.com/paths
+Edit SVG paths in the browser https://jxnblk.github.io/paths
 
 ## About
 


### PR DESCRIPTION
Since `http://jxnblk.com/paths` is not working now, replace it with the demo URL for gh-pages.