### PR TITLE
Apply babel-loader to jxnblk-avatar module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 
 var webpack = require('webpack')
+var path = require('path')
 
 module.exports = {
 
@@ -17,6 +18,7 @@ module.exports = {
   module: {
     loaders: [
       { test: /(\.js$|\.jsx?$)/, exclude: /node_modules/, loaders: ['react-hot', 'babel'] },
+      { test: /\.js$/, include: path.resolve(__dirname, './node_modules/blk/node_modules/jxnblk-avatar/src'), loaders: ['babel'] },
       { test: /\.json$/, loader: 'json-loader' },
       { test: /\.css$/, loader: 'style-loader!css-loader!cssnext-loader' }
     ]


### PR DESCRIPTION
I met this error on `npm start`:

```
ERROR in ./~/blk/~/jxnblk-avatar/src/Avatar.js
Module parse failed: /mnt/c/node/fork/paths/node_modules/blk/node_modules/jxnblk-avatar/src/Avatar.js Unexpected token (9:2)
You may need an appropriate loader to handle this file type.
SyntaxError: Unexpected token (9:2)
```

This is caused by using Spread Operator(needs apply babel or use Webpack4 maybe) in node_modules.

https://github.com/jxnblk/avatar/blob/master/src/Avatar.js#L9

It is necessary to apply babel to jxnblk-avatar, but it can be avoided by applying workaround to webpack.config.js.